### PR TITLE
fix gcc13 compiler error since cstdint is not included on aarch64

### DIFF
--- a/src/xmlparser.hpp
+++ b/src/xmlparser.hpp
@@ -6,7 +6,9 @@
 #ifndef xmlpp_parser_hpp
 #define xmlpp_parser_hpp
 
+#include <cstdint>
 #include "delegate.hpp" 
+
 namespace xmlpp {
 
 


### PR DESCRIPTION
The header includes have changed in compiler versions resulting in uint8_t being undefined in the later compilers

    In file included from glibexpatpp/src/xmlparser.cpp:8:
    glibexpatpp/src/xmlparser.hpp:16:8: warning: elaborated-type-specifier for a scoped enum must not use the 'class' keyword
       16 |   enum class result : uint8_t {
          |   ~~~~ ^~~~~
          |        -----
    glibexpatpp/src/xmlparser.hpp:16:14: error: use of enum 'result' without previous declaration
       16 |   enum class result : uint8_t {
          |              ^~~~~~
    glibexpatpp/src/xmlparser.hpp:16:23: error: 'uint8_t' was not declared in this scope
       16 |   enum class result : uint8_t {
          |                       ^~~~~~~
    glibexpatpp/src/xmlparser.hpp:10:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
        9 | #include "delegate.hpp"
      +++ |+#include <cstdint>
       10 | namespace xmlpp {
    glibexpatpp/src/xmlparser.hpp:16:31: error: default member initializer for unnamed bit-field
       16 |   enum class result : uint8_t {
          |                               ^
    glibexpatpp/src/xmlparser.hpp:78:10: error: 'result' does not name a type
       78 |   static result parseString(const char*pszString, delegate& delegate);
          |          ^~~~~~
    glibexpatpp/src/xmlparser.hpp:79:10: error: 'result' does not name a type
       79 |   static result parseFile(const std::string& filename, delegate& delegate);
          |          ^~~~~~
    glibexpatpp/src/xmlparser.cpp:235:16: error: 'result' in 'class xmlpp::parser' does not name a type
      235 | xmlpp::parser::result  parser::parseString(const char* pszString,
          |                ^~~~~~
    glibexpatpp/src/xmlparser.cpp:262:16: error: 'result' in 'class xmlpp::parser' does not name a type
      262 | xmlpp::parser::result parser::parseFile(const std::string& filename,
          |                ^~~~~~
    make[7]: *** [CMakeFiles/expatpp.dir/build.make:76: CMakeFiles/expatpp.dir/src/xmlparser.cpp.o] Error 1